### PR TITLE
ci: build as matrix; use ccache

### DIFF
--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -50,7 +50,7 @@ jobs:
         platform-release: "jug_xl:nightly"
         run: |
           # install this repo
-          CC=${{ matrix.CC }} CXX=${{ matrix.CC }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          CC=${{ matrix.CC }} CXX=${{ matrix.CXX }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -j 2 install
     - uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -58,6 +58,7 @@ jobs:
         path: |
           .
           !src/
+          !build/
           !apt_cache/
         if-no-files-found: error
 

--- a/.github/workflows/linux-eic-shell.yml
+++ b/.github/workflows/linux-eic-shell.yml
@@ -14,44 +14,47 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-gcc:
+  build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - CC: gcc
+            CXX: g++
+          - CC: clang
+            CXX: clang++
     steps:
     - uses: actions/checkout@v3
+    - name: Prepare ccache timestamp
+      id: ccache_cache_timestamp
+      run: |
+        echo "timestamp=$(date --iso-8601=minutes)" >> $GITHUB_OUTPUT
+    - name: Retrieve ccache cache files
+      uses: actions/cache@v3
+      with:
+        path: .ccache
+        key: ccache-${{ matrix.CC }}-${{ github.ref_name }}-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+        restore-keys: |
+             ccache-${{ matrix.CC }}-${{ github.ref_name }}-
+             ccache-${{ matrix.CC }}-
+             ccache-
+    - name: Configure ccache
+      run: |
+        mkdir -p ~/.ccache/
+        echo "cache_dir=${{ github.workspace }}/.ccache" >> ~/.ccache/ccache.conf
+        echo "max_size=500MB" >> ~/.ccache/ccache.conf
+        echo "compression=true" >> ~/.ccache/ccache.conf
     - uses: cvmfs-contrib/github-action-cvmfs@v3
     - uses: eic/run-cvmfs-osg-eic-shell@main
       with:
         platform-release: "jug_xl:nightly"
         run: |
           # install this repo
-          CC=gcc CXX=g++ cmake -B build -S .
+          CC=${{ matrix.CC }} CXX=${{ matrix.CC }} cmake -B build -S . -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build build -- -j 2 install
     - uses: actions/upload-artifact@v3
       with:
-        name: build-gcc-eic-shell
-        path: |
-          .
-          !src/
-          !apt_cache/
-        if-no-files-found: error
-
-  build-clang:
-    runs-on: ubuntu-latest
-    needs:
-    - build-gcc
-    steps:
-    - uses: actions/checkout@v3
-    - uses: cvmfs-contrib/github-action-cvmfs@v3
-    - uses: eic/run-cvmfs-osg-eic-shell@main
-      with:
-        platform-release: "jug_xl:nightly"
-        run: |
-          # install this repo
-          CC=clang CXX=clang++ cmake -B build -S .
-          cmake --build build -- -j 2 install
-    - uses: actions/upload-artifact@v3
-      with:
-        name: build-clang-eic-shell
+        name: build-${{ matrix.CC }}-eic-shell
         path: |
           .
           !src/
@@ -81,7 +84,7 @@ jobs:
   eicrecon-gcc:
     runs-on: ubuntu-latest
     needs:
-    - build-gcc
+    - build
     - ddsim
     strategy:
       matrix:
@@ -118,7 +121,7 @@ jobs:
   run_eicrecon_reco_flags-gcc:
     runs-on: ubuntu-latest
     needs:
-    - build-gcc
+    - build
     - ddsim
     strategy:
       matrix:


### PR DESCRIPTION
### Briefly, what does this PR introduce?
The build takes 15 minutes, and likely most files don't change frequently. We can use ccache to speed up. Rather than implementing the caching twice, this moves the builds with gcc and clang into a matrix build. This improves build times to 3 minutes:
![image](https://user-images.githubusercontent.com/4656391/202869410-220ceef0-1a78-433c-90df-39d17c1b5b0e.png)

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [x] New feature (issue: faster CI builds)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?
No.

### Does this PR change default behavior?
No.